### PR TITLE
Add basic gamification and missions

### DIFF
--- a/database/__init__.py
+++ b/database/__init__.py
@@ -1,4 +1,4 @@
-from .models import Base, User, Channel, UserChannel
+from .models import Base, User, Channel, UserChannel, Mission, UserMission, UserAchievement, LorePiece, UserLorePiece
 from .connection import init_db, get_db
 
 __all__ = [
@@ -6,6 +6,11 @@ __all__ = [
     'User',
     'Channel',
     'UserChannel',
+    'Mission',
+    'UserMission',
+    'UserAchievement',
+    'LorePiece',
+    'UserLorePiece',
     'init_db',
     'get_db',
 ]

--- a/database/models.py
+++ b/database/models.py
@@ -32,3 +32,47 @@ class UserChannel(Base):
     channel_id = Column(Integer, ForeignKey('channels.id'))
     user = relationship('User', back_populates='channels')
     channel = relationship('Channel', back_populates='users')
+
+class Mission(Base):
+    __tablename__ = 'missions'
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    description = Column(String)
+    reward_besitos = Column(Integer, default=0)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    expires_at = Column(DateTime)
+    user_missions = relationship('UserMission', back_populates='mission')
+
+class UserMission(Base):
+    __tablename__ = 'user_missions'
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey('users.id'))
+    mission_id = Column(Integer, ForeignKey('missions.id'))
+    progress = Column(Integer, default=0)
+    completed = Column(Boolean, default=False)
+    assigned_at = Column(DateTime, default=datetime.utcnow)
+    user = relationship('User')
+    mission = relationship('Mission', back_populates='user_missions')
+
+class UserAchievement(Base):
+    __tablename__ = 'user_achievements'
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey('users.id'))
+    name = Column(String)
+    achieved_at = Column(DateTime, default=datetime.utcnow)
+    user = relationship('User')
+
+class LorePiece(Base):
+    __tablename__ = 'lore_pieces'
+    id = Column(Integer, primary_key=True)
+    name = Column(String, unique=True)
+    description = Column(String)
+
+class UserLorePiece(Base):
+    __tablename__ = 'user_lore_pieces'
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey('users.id'))
+    lore_piece_id = Column(Integer, ForeignKey('lore_pieces.id'))
+    acquired_at = Column(DateTime, default=datetime.utcnow)
+    user = relationship('User')
+    lore_piece = relationship('LorePiece')

--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -1,4 +1,13 @@
 from .start_handler import router as start_router
 from .channel_handlers import router as channel_router
+from .gamification_handlers import router as gamification_router
+from .missions_handlers import router as missions_router
+from .gifts_handlers import router as gifts_router
 
-__all__ = ['start_router', 'channel_router']
+__all__ = [
+    'start_router',
+    'channel_router',
+    'gamification_router',
+    'missions_router',
+    'gifts_router',
+]

--- a/handlers/gamification_handlers.py
+++ b/handlers/gamification_handlers.py
@@ -1,0 +1,15 @@
+from aiogram import types, Router
+from middlewares import UserContext
+from services.gamification_service import GamificationService
+from utils.keyboards import MAIN_MENU
+
+router = Router()
+service = GamificationService()
+
+@router.message(lambda m: m.text == '🏆 Mi Perfil')
+async def profile(message: types.Message, user_context: UserContext):
+    text = (
+        f"💖 Besitos: {user_context.besitos}\n"
+        f"⭐ Nivel: {user_context.level}"
+    )
+    await message.answer(text, reply_markup=MAIN_MENU)

--- a/handlers/gifts_handlers.py
+++ b/handlers/gifts_handlers.py
@@ -1,0 +1,15 @@
+from aiogram import types, Router
+from middlewares import UserContext
+from services.gift_service import GiftService
+from utils.keyboards import MAIN_MENU
+
+router = Router()
+service = GiftService()
+
+@router.message(lambda m: m.text == '🎁 Regalo Diario')
+async def daily_gift(message: types.Message, user_context: UserContext):
+    claimed = await service.claim_daily_gift(user_context.user_id)
+    if claimed:
+        await message.answer('🎁 Has recibido 20 besitos!', reply_markup=MAIN_MENU)
+    else:
+        await message.answer('⏳ Ya reclamaste el regalo de hoy.', reply_markup=MAIN_MENU)

--- a/handlers/missions_handlers.py
+++ b/handlers/missions_handlers.py
@@ -1,0 +1,16 @@
+from aiogram import types, Router
+from middlewares import UserContext
+from services.mission_service import MissionService
+from utils.keyboards import MAIN_MENU
+
+router = Router()
+service = MissionService()
+
+@router.message(lambda m: m.text == '🎯 Misiones')
+async def missions(message: types.Message, user_context: UserContext):
+    missions = await service.get_user_missions(user_context.user_id)
+    if not missions:
+        await service.assign_daily_mission(user_context.user_id)
+        missions = await service.get_user_missions(user_context.user_id)
+    text = '\n'.join(f"- {m.mission.name}: {'✅' if m.completed else '❌'}" for m in missions)
+    await message.answer(f"Tus misiones:\n{text}", reply_markup=MAIN_MENU)

--- a/main.py
+++ b/main.py
@@ -5,8 +5,7 @@ from config import get_settings
 from database import init_db
 from middlewares.auth_middleware import AuthMiddleware
 from middlewares.session_middleware import SessionMiddleware
-from handlers import start_router, channel_router
-
+from handlers import start_router, channel_router, gamification_router, missions_router, gifts_router
 settings = get_settings()
 
 bot = Bot(token=settings.BOT_TOKEN)
@@ -16,6 +15,9 @@ dp.middleware.setup(AuthMiddleware())
 dp.middleware.setup(SessionMiddleware())
 
 dp.include_router(start_router)
+dp.include_router(gamification_router)
+dp.include_router(missions_router)
+dp.include_router(gifts_router)
 dp.include_router(channel_router)
 
 if __name__ == '__main__':

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,4 +1,13 @@
 from .user_service import UserService
 from .channel_service import ChannelService
+from .gamification_service import GamificationService
+from .mission_service import MissionService
+from .gift_service import GiftService
 
-__all__ = ['UserService', 'ChannelService']
+__all__ = [
+    'UserService',
+    'ChannelService',
+    'GamificationService',
+    'MissionService',
+    'GiftService',
+]

--- a/services/gamification_service.py
+++ b/services/gamification_service.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from database import get_db, User
+
+class GamificationService:
+    async def add_besitos(self, user_id: int, amount: int, reason: str) -> int:
+        with next(get_db()) as db:
+            user = db.query(User).filter_by(id=user_id).first()
+            if not user:
+                return 0
+            user.besitos += amount
+            user.level = self.calculate_level(user.besitos)
+            db.commit()
+            db.refresh(user)
+            return user.besitos
+
+    def calculate_level(self, besitos: int) -> int:
+        # Simple progression: 100 besitos per level
+        return max(1, besitos // 100 + 1)

--- a/services/gift_service.py
+++ b/services/gift_service.py
@@ -1,0 +1,20 @@
+from datetime import datetime, timedelta
+from database import get_db, User
+from .gamification_service import GamificationService
+
+class GiftService:
+    def __init__(self):
+        self.gamification = GamificationService()
+
+    async def claim_daily_gift(self, user_id: int) -> bool:
+        today = datetime.utcnow().date()
+        with next(get_db()) as db:
+            user = db.query(User).filter_by(id=user_id).first()
+            if not user:
+                return False
+            if user.last_daily_gift == today:
+                return False
+            user.last_daily_gift = today
+            db.commit()
+            await self.gamification.add_besitos(user_id, 20, "daily_gift")
+            return True

--- a/services/mission_service.py
+++ b/services/mission_service.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timedelta
+from typing import List
+from database import get_db, Mission, UserMission
+from .gamification_service import GamificationService
+
+class MissionService:
+    def __init__(self):
+        self.gamification = GamificationService()
+
+    async def assign_daily_mission(self, user_id: int) -> UserMission:
+        with next(get_db()) as db:
+            mission = db.query(Mission).filter(Mission.expires_at > datetime.utcnow()).first()
+            if not mission:
+                mission = Mission(
+                    name="El Desafío Diario",
+                    description="Visita 3 canales diferentes",
+                    reward_besitos=50,
+                    expires_at=datetime.utcnow() + timedelta(hours=24)
+                )
+                db.add(mission)
+                db.commit()
+                db.refresh(mission)
+            user_mission = UserMission(user_id=user_id, mission_id=mission.id)
+            db.add(user_mission)
+            db.commit()
+            db.refresh(user_mission)
+            return user_mission
+
+    async def complete_mission(self, user_mission_id: int):
+        with next(get_db()) as db:
+            um = db.query(UserMission).filter_by(id=user_mission_id, completed=False).first()
+            if not um:
+                return
+            um.completed = True
+            db.commit()
+            await self.gamification.add_besitos(um.user_id, um.mission.reward_besitos, "mission")
+
+    async def get_user_missions(self, user_id: int) -> List[UserMission]:
+        with next(get_db()) as db:
+            return db.query(UserMission).filter_by(user_id=user_id).all()

--- a/utils/keyboards.py
+++ b/utils/keyboards.py
@@ -1,12 +1,16 @@
 from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 
 MAIN_MENU = ReplyKeyboardMarkup(resize_keyboard=True)
-MAIN_MENU.add(
+MAIN_MENU.row(
     KeyboardButton('🏠 Inicio'),
     KeyboardButton('🎁 Regalo Diario'),
     KeyboardButton('🏆 Mi Perfil'),
 )
-MAIN_MENU.add(
+MAIN_MENU.row(
+    KeyboardButton('🎯 Misiones'),
+    KeyboardButton('🎲 Juegos'),
+)
+MAIN_MENU.row(
     KeyboardButton('📺 Canales'),
     KeyboardButton('🔙 Volver'),
 )


### PR DESCRIPTION
## Summary
- add gamification, mission and gift services
- extend database models for missions and lore
- add handlers for gamification, missions and daily gifts
- update keyboard layout
- wire new routers in main

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862f596558c8329b954a71ead2bcc8c